### PR TITLE
* Resize title fields to fit a1 data

### DIFF
--- a/migrations/064_resize_title_fields.rb
+++ b/migrations/064_resize_title_fields.rb
@@ -1,0 +1,17 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:physical_representation) do
+      set_column_type :title, :varchar, :size=>300, :null => true
+    end
+    alter_table(:digital_representation) do
+      set_column_type :title, :varchar, :size=>300, :null => true
+    end
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
A1 description and format are mapped to description, causing some rows to exceed the max size. the max size is 261, but I've added some wiggle room.