### PR TITLE
* Fix enum capitalisation

### DIFF
--- a/migrations/113_digital_media_enum_fix.rb
+++ b/migrations/113_digital_media_enum_fix.rb
@@ -4,7 +4,7 @@ Sequel.migration do
   up do
     self.transaction do
       old_enum_id = self[:enumeration_value][:value => 'Digital Media - Other'][:id]
-      new_enum_id = self[:enumeration_value][:value => 'Digital media - Other'][:id]
+      new_enum_id = self[:enumeration_value][:value => 'Digital Media - Other'][:id]
 
       self[:digital_representation].filter(:contained_within_id => old_enum_id).update(:contained_within_id => new_enum_id)
       self[:enumeration_value].filter(:id => old_enum_id).delete


### PR DESCRIPTION
Missed capital on the enum value was causing the migration to fail.